### PR TITLE
Build Fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ go:
   - 1.16.x
 
 before_install:
-  - docker login -u "${DOCKER_GCP_USERNAME}" --password-stdin "${DOCKER_GCP_PASSWORD}" "${DOCKER_GCP_REGISTRY}";
+  - echo "${DOCKER_GCP_PASSWORD}" | docker login -u "${DOCKER_GCP_USERNAME}" --password-stdin "${DOCKER_GCP_REGISTRY}";
 
 script:
   - make format-check

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ go:
   - 1.16.x
 
 before_install:
-  - docker login -u "${DOCKER_GCP_USERNAME}" -p "${DOCKER_GCP_PASSWORD}" "${DOCKER_GCP_REGISTRY}"
+  - docker login -u "${DOCKER_GCP_USERNAME}" --password-stdin "${DOCKER_GCP_REGISTRY}" < "${DOCKER_GCP_PASSWORD}"
 
 script:
   - make format-check

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ go:
   - 1.16.x
 
 before_install:
-  - docker login -u "${DOCKER_GCP_USERNAME}" -p "${DOCKER_GCP_PASSWORD}" "${DOCKER_GCP_REGISTRY}";
+  - docker login -u "${DOCKER_GCP_USERNAME}" --password-stdin "${DOCKER_GCP_PASSWORD}" "${DOCKER_GCP_REGISTRY}";
 
 script:
   - make format-check

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ go:
   - 1.16.x
 
 before_install:
-  - echo "${DOCKER_GCP_PASSWORD}" | docker login -u "${DOCKER_GCP_USERNAME}" --password-stdin "${DOCKER_GCP_REGISTRY}";
+  - docker login -u "${DOCKER_GCP_USERNAME}" -p "${DOCKER_GCP_PASSWORD}" "${DOCKER_GCP_REGISTRY}"
 
 script:
   - make format-check

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ go:
   - 1.16.x
 
 before_install:
-  - docker login -u "${DOCKER_GCP_USERNAME}" --password-stdin "${DOCKER_GCP_REGISTRY}" < "${DOCKER_GCP_PASSWORD}"
+  - docker login -u "${DOCKER_GCP_USERNAME}" -p "${DOCKER_GCP_PASSWORD}" "${DOCKER_GCP_REGISTRY}";
 
 script:
   - make format-check

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ services:
 langauge: go
 
 go:
-  - 1.14.x
+  - 1.16.x
 
 script:
   - make format-check

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,9 @@ langauge: go
 go:
   - 1.16.x
 
+before_install:
+  - docker login -u "${DOCKER_GCP_USERNAME}" -p "${DOCKER_GCP_PASSWORD}" "${DOCKER_GCP_REGISTRY}";
+
 script:
   - make format-check
   - make build

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ unit-test:
 	go test -race ./... -tags=unitTest
 
 run-int-test:
-	PUBSUB_EMULATOR_HOST=localhost:8539 go test -count 1 github.com/ONSdigital/ssdc-rm-pubsub-adapter
+	PUBSUB_EMULATOR_HOST=localhost:8538 go test -count 1 github.com/ONSdigital/ssdc-rm-pubsub-adapter
 
 int-test: down up-dependencies run-int-test down
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ RABBIT_PORT=7672
 RABBIT_USERNAME=guest
 RABBIT_PASSWORD=guest
 EQ_RECEIPT_PROJECT=project
-PUBSUB_EMULATOR_HOST=localhost:8539
+PUBSUB_EMULATOR_HOST=localhost:8538
 EQ_RECEIPT_PROJECT=project
 QUARANTINE_MESSAGE_URL=http://httpbin.org/post
 RABBIT_EXCHANGE=
@@ -60,7 +60,7 @@ This will run the formatter, build and units tests then spin up the dependencies
 ## Debugging the tests
 To run the integration tests in an IDE
  1. Run `make up-dependencies` to start up the dependencies with docker-compose.
- 1. Set the environment variable `PUBSUB_EMULATOR_HOST=localhost:8539` in your IDE run configuration
+ 1. Set the environment variable `PUBSUB_EMULATOR_HOST=localhost:8538` in your IDE run configuration
  1. Run the test in debug mode
 
 ## Formatting
@@ -81,6 +81,6 @@ You can then run `make logs` to tail the logs
 ### Post in a test message
 You can send a test message onto the pubsub emulator with the tools script
 ```sh
-PUBSUB_EMULATOR_HOST=localhost:8539 go run tools/publish_message.go
+PUBSUB_EMULATOR_HOST=localhost:8538 go run tools/publish_message.go
 ```
 You should see the pubsub adapter log that it has processed the message and see the rabbit messages it produced in the rabbit management UI at http://localhost:17672 (login: guest, guest).

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,7 @@ services:
 
   pubsub-emulator:
     container_name: pubsub-emulator-pubsub-adapter-dev
-    image: bigtruedata/gcloud-pubsub-emulator
+    image: eu.gcr.io/ssdc-rm-ci/rm/gcloud-pubsub-emulator:latest
     ports:
       - "8539:8539"
     command: start --host-port 0.0.0.0:8539

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,14 +19,13 @@ services:
     container_name: pubsub-emulator-pubsub-adapter-dev
     image: eu.gcr.io/ssdc-rm-ci/rm/gcloud-pubsub-emulator:latest
     ports:
-      - "8539:8539"
-    command: start --host-port 0.0.0.0:8539
+      - "8538:8538"
 
   pubsub-adapter:
     container_name: pubsub-adapter-dev
     image: eu.gcr.io/ssdc-rm-ci/rm/ssdc-rm-pubsub-adapter
     environment:
-      - PUBSUB_EMULATOR_HOST=pubsub-emulator-pubsub-adapter-dev:8539
+      - PUBSUB_EMULATOR_HOST=pubsub-emulator-pubsub-adapter-dev:8538
       - RABBIT_CONNECTION=amqp://guest:guest@rabbitmq-pubsub-adapter-dev:5672/
       - RABBIT_USERNAME=guest
       - RABBIT_PASSWORD=guest

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ONSdigital/ssdc-rm-pubsub-adapter
 
-go 1.15
+go 1.16
 
 require (
 	cloud.google.com/go/pubsub v1.11.0

--- a/setup_dependencies.sh
+++ b/setup_dependencies.sh
@@ -23,10 +23,10 @@ wait_for_curl_success() {
     echo "[$service_name] is ready"
 }
 
-wait_for_curl_success "http://localhost:8539/v1/projects/project/topics/eq-submission-topic" "PUT" "pubsub_emulator topic"
+wait_for_curl_success "http://localhost:8538/v1/projects/project/topics/eq-submission-topic" "PUT" "pubsub_emulator topic"
 
 echo "Setting up subscriptions to topics..."
-curl -X PUT http://localhost:8539/v1/projects/project/subscriptions/rm-receipt-subscription -H 'Content-Type: application/json' -d '{"topic": "projects/project/topics/eq-submission-topic"}'
+curl -X PUT http://localhost:8538/v1/projects/project/subscriptions/rm-receipt-subscription -H 'Content-Type: application/json' -d '{"topic": "projects/project/topics/eq-submission-topic"}'
 
 wait_for_curl_success "http://guest:guest@localhost:17672/api/aliveness-test/%2F" "GET" "rabbitmq"
 


### PR DESCRIPTION
# Motivation and Context

A collection of small issues with the pubsub adapter build:

- Use the same go version as the image is built with, currently 1.16
- Add GCR config/auth in travis
- Use our own pubsub emulator image (currently it's using the massive big true image)

# What has changed
Updated image name
Go versions updated
Updated travis file

# How to test?
Build image and check it works ok

# Links
https://trello.com/c/qoAU28OW