### PR TITLE
Make routing keys consistent

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -22,7 +22,7 @@ type Configuration struct {
 	RabbitVHost            string `envconfig:"RABBIT_VHOST"  default:"/"`
 	RabbitConnectionString string `json:"-"`
 	EventsExchange         string `envconfig:"RABBIT_EXCHANGE"  default:"events"`
-	ReceiptRoutingKey      string `envconfig:"RECEIPT_ROUTING_KEY"  default:"events.caseProcessor.response"`
+	ReceiptRoutingKey      string `envconfig:"RECEIPT_ROUTING_KEY"  default:"events.response"`
 
 	// PubSub
 	EqReceiptProject      string `envconfig:"EQ_RECEIPT_PROJECT" required:"true"`


### PR DESCRIPTION
# Motivation and Context
Routing key != queue name. If you want to send directly to a queue, use the default exchange. Otherwise, use the `events` exchange with a meaningful routing key.

# What has changed
Named the routing keys better.

# How to test?
Run the ATs. Should be zero regression.

# Links
Trello: https://trello.com/c/4CgML4w6