### PR TITLE
3213 Migrate from container registry to artifact registry

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ go:
   - 1.16.x
 
 before_install:
-  - docker login -u "${DOCKER_GCP_USERNAME}" -p "${DOCKER_GCP_PASSWORD}" "${DOCKER_GCP_REGISTRY}";
+  - docker login -u "${DOCKER_GCP_USERNAME}" -p "${DOCKER_GCP_PASSWORD}" https://europe-west2-docker.pkg.dev;
 
 script:
   - make format-check

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ down:
 	docker-compose down
 
 docker:
-	docker build -t eu.gcr.io/ssdc-rm-ci/rm/ssdc-rm-pubsub-adapter .
+	docker build -t europe-west2-docker.pkg.dev/ssdc-rm-ci/docker/ssdc-rm-pubsub-adapter .
 
 build:
 	go build -race .

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,13 +17,13 @@ services:
 
   pubsub-emulator:
     container_name: pubsub-emulator-pubsub-adapter-dev
-    image: eu.gcr.io/ssdc-rm-ci/rm/gcloud-pubsub-emulator:latest
+    image: europe-west2-docker.pkg.dev/ssdc-rm-ci/docker/gcloud-pubsub-emulator:latest
     ports:
       - "8538:8538"
 
   pubsub-adapter:
     container_name: pubsub-adapter-dev
-    image: eu.gcr.io/ssdc-rm-ci/rm/ssdc-rm-pubsub-adapter
+    image: europe-west2-docker.pkg.dev/ssdc-rm-ci/docker/ssdc-rm-pubsub-adapter
     environment:
       - PUBSUB_EMULATOR_HOST=pubsub-emulator-pubsub-adapter-dev:8538
       - RABBIT_CONNECTION=amqp://guest:guest@rabbitmq-pubsub-adapter-dev:5672/

--- a/pubsub-adapter-deployment.yml
+++ b/pubsub-adapter-deployment.yml
@@ -25,7 +25,7 @@ spec:
     spec:
       containers:
         - name: pubsub-adapter
-          image: eu.gcr.io/ssdc-rm-ci/rm/ssdc-rm-pubsub-adapter:latest
+          image: europe-west2-docker.pkg.dev/ssdc-rm-ci/docker/ssdc-rm-pubsub-adapter:latest
           imagePullPolicy: Always
           resources:
             requests:


### PR DESCRIPTION
# Motivation and Context
We are moving our images to an artifact registry.

# What has changed
- Update image URIs

# How to test?
Check the new image URIs are correct

# Links
https://trello.com/c/0LziJk8R/3213-migrate-from-container-registrys-to-artifact-registry-using-standard-repository-8